### PR TITLE
Update Splice main to version 0.2.0-snapshot.20240809.6661.0.vb0dfa211 (automatic PR)

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,6 +1,6 @@
 
 {
-  "version": "3.1.0-snapshot.20240808.13753.0.vbe9fc3b4",
+  "version": "3.1.0-snapshot.20240807.13752.0.v55a65d98",
   "tooling_sdk_version": "3.1.0-snapshot.20240717.13187.0.va47ab77f",
-  "sha256": "sha256:1cxx9xh7x3jk0r3cnbnvmd4r02jbm5i9n8lglavb6h4mwwwd6jdk"
+  "sha256": "sha256:15m9ryk5n2kcp1gnldi1fkz4nsv5zmykw12nahad84gx7zz527my"
 }


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.2.0-snapshot.20240809.6661.0.vb0dfa211, commit DACH-NY/canton-network-node@b0dfa211d