### PR TITLE
Update Splice main to version 0.2.0-snapshot.20240822.6772.0.v1575340a (automatic PR)

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,6 +1,6 @@
 
 {
-  "version": "3.1.0-snapshot.20240821.13760.0.v9b7fa740",
+  "version": "3.1.0-snapshot.20240821.13761.0.ve7e10ea9",
   "tooling_sdk_version": "3.1.0-snapshot.20240717.13187.0.va47ab77f",
-  "sha256": "sha256:16671m4p5w4f3mh9ld4z5sxli80bk3yx06m0d9xjqywkzb2bv0pc"
+  "sha256": "sha256:0mnkiw85bay3vqdnsrbx00a37f03akynr7qgvabb3nznm5wk22rj"
 }


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.2.0-snapshot.20240822.6772.0.v1575340a, commit DACH-NY/canton-network-node@1575340ad