### PR TITLE
Update Splice isegall/multi-arch-fix-digests to version 0.2.1-snapshot.20240912.6969.0.v02a45cb7 (automatic PR)

### DIFF
--- a/.envrc.vars
+++ b/.envrc.vars
@@ -27,3 +27,6 @@ if stat --printf='' .envrc.vars.* 2>/dev/null; then
     source_env $file || . $file
   done
 fi
+
+pulumi_version=$(pulumi version)
+export PULUMI_VERSION="${pulumi_version:1}"

--- a/cluster/images/ans-web-ui/Dockerfile
+++ b/cluster/images/ans-web-ui/Dockerfile
@@ -2,17 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-FROM nginx:stable
-RUN apt-get update && \
-  apt-get install -y tini
+ARG base_version
+FROM --platform=$BUILDPLATFORM splice-app:${base_version} AS build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-COPY default.conf /etc/nginx/conf.d
-COPY --from=0 app/splice-node/web-uis/ans /usr/share/nginx/html/
+COPY --from=xx / /
 
-COPY config.js /tmpl/config.js.tmpl
+RUN xx-apt-get update && \
+  xx-apt-get install -y tini
 
 COPY docker-entrypoint.sh /custom-docker-entrypoint.sh
 RUN chmod 500 /custom-docker-entrypoint.sh
+
+FROM nginx:stable
+
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=build app/splice-node/web-uis/ans /usr/share/nginx/html/
+
+COPY default.conf /etc/nginx/conf.d
+COPY config.js /tmpl/config.js.tmpl
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/custom-docker-entrypoint.sh"]

--- a/cluster/images/canton-cometbft-sequencer/Dockerfile
+++ b/cluster/images/canton-cometbft-sequencer/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 EXPOSE 5008
 EXPOSE 5009

--- a/cluster/images/canton-domain/Dockerfile
+++ b/cluster/images/canton-domain/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 EXPOSE 5007
 EXPOSE 5008

--- a/cluster/images/canton-mediator/Dockerfile
+++ b/cluster/images/canton-mediator/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 EXPOSE 5007
 EXPOSE 10013

--- a/cluster/images/canton-participant/Dockerfile
+++ b/cluster/images/canton-participant/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 EXPOSE 5001
 EXPOSE 5002

--- a/cluster/images/canton-sequencer/Dockerfile
+++ b/cluster/images/canton-sequencer/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 EXPOSE 5008
 EXPOSE 5009

--- a/cluster/images/canton/Dockerfile
+++ b/cluster/images/canton/Dockerfile
@@ -1,13 +1,21 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# This Dockerfile is a modified version of Canton's Dockerfile
-FROM eclipse-temurin:17-jdk-jammy
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS build
+
+COPY --from=xx / /
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # Install screen for running the console in a headless server
-RUN apt-get update \
-   && DEBIAN_FRONTEND=noninteractive apt-get install -y screen tini \
-   && apt-get clean \
+RUN xx-apt-get update \
+   && DEBIAN_FRONTEND=noninteractive xx-apt-get install -y screen tini \
+   && xx-apt-get clean \
    && rm -rf /var/cache/apt/archives
 
 # create and switch to a working directory
@@ -20,6 +28,13 @@ ADD target/canton.tar .
 COPY target/monitoring.conf target/entrypoint.sh target/bootstrap-entrypoint.sc target/tools.sh target/logback.xml /app/
 
 RUN ln -s bin/canton splice-image-bin
+
+FROM eclipse-temurin:17-jdk-jammy
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /usr/bin/screen /usr/bin/screen
+COPY --from=build /app/ /app/
+
+WORKDIR /app
 
 # point entrypoint to the amulet executable
 ENTRYPOINT ["/usr/bin/tini", "--", "/app/entrypoint.sh"]

--- a/cluster/images/docs/Dockerfile
+++ b/cluster/images/docs/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 FROM nginx:stable
 ARG version

--- a/cluster/images/gcs-proxy/Dockerfile
+++ b/cluster/images/gcs-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM debian:buster-slim
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim
 
 WORKDIR /tmp
 ENV GCSPROXY_VERSION=0.3.1

--- a/cluster/images/load-tester/Dockerfile
+++ b/cluster/images/load-tester/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 grafana/k6:0.48.0
+FROM grafana/k6:0.48.0
 
 COPY entrypoint.sh .
 COPY target/test/* ./

--- a/cluster/images/local.mk
+++ b/cluster/images/local.mk
@@ -36,6 +36,7 @@ splice-image := cluster/images/splice-app
 ifdef CI
     # never use the cache in CI on the master branch
     cache_opt := --no-cache
+    platform_opt := --platform=linux/amd64,linux/arm64
 else
     # Local builds (which may be on an M1) are explicitly constrained
     # to x86.
@@ -78,6 +79,7 @@ $$(prefix)/docker-check: $$(prefix)/$(docker-image-tag)
 .PHONY: $$(prefix)/clean
 $$(prefix)/clean:
 	-rm -vfr $$(@D)/target
+
 endef # end DEFINE_PHONY_RULES
 
 $(foreach image,$(images),$(eval $(call DEFINE_PHONY_RULES,$(image))))
@@ -95,9 +97,10 @@ $(foreach image,$(images),$(eval $(call DEFINE_PHONY_RULES,$(image))))
 	get-docker-image-name $$(basename $$(dirname $(@D))) > $@
 
 %/$(docker-build): %/$(docker-local-image-tag) %/Dockerfile
+	docker-check-multi-arch
 	mkdir -pv $(@D)
 	@echo docker build triggered because these files changed: $?
-	docker build $(platform_opt) --iidfile $@ $(cache_opt) $(build_arg) -t $$(cat $<) $(@D)/..
+	docker buildx build $(platform_opt) --iidfile $@ $(cache_opt) $(build_arg) -t $$(cat $<) $(@D)/..
 
 %/$(docker-push):  %/$(docker-image-tag) %/$(docker-build)
 	cd $(@D)/.. && docker-push $$(cat $(abspath $<))

--- a/cluster/images/multi-participant/Dockerfile
+++ b/cluster/images/multi-participant/Dockerfile
@@ -3,6 +3,6 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 canton:${base_version}
+FROM canton:${base_version}
 
 COPY pre-bootstrap.sh app.conf /app/

--- a/cluster/images/multi-validator/Dockerfile
+++ b/cluster/images/multi-validator/Dockerfile
@@ -3,6 +3,6 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 COPY app.conf bootstrap.sc pre-bootstrap.sh health-check.sh /app/

--- a/cluster/images/multi-validator/health-check.sh
+++ b/cluster/images/multi-validator/health-check.sh
@@ -12,7 +12,7 @@ function check_endpoint() {
     local validator_admin_port=$(( base_port + 3 ))
 
     local status
-    status=$(curl -w "%{http_code}" "http://127.0.0.1:${validator_admin_port}/$endpoint")
+    status=$(wget --server-response --quiet "http://127.0.0.1:${validator_admin_port}/$endpoint" 2>&1 | awk 'NR==1{print $2}')
 
     if [[ "$status" != "200" ]];
     then

--- a/cluster/images/multi-validator/pre-bootstrap.sh
+++ b/cluster/images/multi-validator/pre-bootstrap.sh
@@ -21,7 +21,7 @@ function request_onboarding_secret() {
 
         until [ $n -gt $MAX_RETRY ]; do
 
-            if SECRET=$(curl -sSfL -X POST "${ONBOARD_SECRET_URL}" 2> /dev/null); then
+            if SECRET=$(wget --post-data="" -q -O - "${ONBOARD_SECRET_URL}"); then
                 echo "$SECRET"
                 break
             else

--- a/cluster/images/pulumi-kubernetes-operator/Dockerfile
+++ b/cluster/images/pulumi-kubernetes-operator/Dockerfile
@@ -5,14 +5,16 @@
 # used to control he underlyign pulumi version
 ARG pulumi_version
 
-# use the nix version back once it's >3.113 (has required ts support)
-FROM pulumi/pulumi:3.113.3
+FROM pulumi/pulumi:${pulumi_version}
 
-RUN apt-get install tini
+RUN apt-get update \
+    && apt-get install tini \
+    && apt-get clean
+
 ENTRYPOINT ["tini", "--", "/usr/local/bin/pulumi-kubernetes-operator"]
 
 # install operator binary
-RUN wget -O - -c "https://github.com/pulumi/pulumi-kubernetes-operator/releases/download/v1.15.0/pulumi-kubernetes-operator_.1.15.0_.Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin/
+RUN wget -O - -c "https://github.com/pulumi/pulumi-kubernetes-operator/releases/download/v1.16.0/pulumi-kubernetes-operator_.1.16.0_.Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin/
 
 COPY pulumi-override.sh /usr/bin/pulumi-override.sh
 RUN useradd -m pulumi-kubernetes-operator

--- a/cluster/images/scan-app/Dockerfile
+++ b/cluster/images/scan-app/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 EXPOSE 10013
 

--- a/cluster/images/scan-web-ui/Dockerfile
+++ b/cluster/images/scan-web-ui/Dockerfile
@@ -2,16 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-FROM nginx:stable
-RUN apt-get update && \
-    apt-get install -y gettext tini
-COPY default.conf /etc/nginx/conf.d
-COPY --from=0 app/splice-node/web-uis/scan /usr/share/nginx/html/
+ARG base_version
+FROM --platform=$BUILDPLATFORM splice-app:${base_version} AS build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-COPY config.js /tmpl/config.js.tmpl
+COPY --from=xx / /
+
+RUN xx-apt-get update && \
+  xx-apt-get install -y tini
 
 COPY docker-entrypoint.sh /custom-docker-entrypoint.sh
 RUN chmod 500 /custom-docker-entrypoint.sh
+
+FROM nginx:stable
+
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=build app/splice-node/web-uis/scan /usr/share/nginx/html/
+
+COPY default.conf /etc/nginx/conf.d
+COPY config.js /tmpl/config.js.tmpl
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/custom-docker-entrypoint.sh"]

--- a/cluster/images/splice-app/Dockerfile
+++ b/cluster/images/splice-app/Dockerfile
@@ -1,15 +1,26 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# This Dockerfile is a modified version of Canton's Dockerfile
-FROM eclipse-temurin:17-jdk-jammy
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS build
+
+COPY --from=xx / /
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # Install screen for running the console in a headless server,
-# and curl for getting onboarding secrets.
-RUN apt-get update \
-   && DEBIAN_FRONTEND=noninteractive apt-get install -y screen curl tini \
-   && apt-get clean \
+RUN xx-apt-get update \
+   && DEBIAN_FRONTEND=noninteractive xx-apt-get install -y screen tini \
+   && xx-apt-get clean \
    && rm -rf /var/cache/apt/archives
+
+# Note that we do not currently install curl, since it's harder to copy to the following stages.
+# We cuse wget instead, which suffices for now. If we end up needing curl, we should consider using
+# https://github.com/moparisthebest/static-curl.
 
 # create and switch to a working directory
 RUN mkdir /app
@@ -21,6 +32,14 @@ ADD target/splice-node.tar.gz .
 COPY target/monitoring.conf target/entrypoint.sh target/bootstrap-entrypoint.sc target/tools.sh target/LICENSE /app/
 
 RUN ln -s splice-node/bin/splice-node splice-image-bin
+
+# This Dockerfile is a modified version of Canton's Dockerfile
+FROM eclipse-temurin:17-jdk-jammy
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /usr/bin/screen /usr/bin/screen
+COPY --from=build /app/ /app/
+
+WORKDIR /app
 
 # point entrypoint to the splice-node executable
 ENTRYPOINT ["/usr/bin/tini", "--", "/app/entrypoint.sh"]

--- a/cluster/images/splice-debug/Dockerfile
+++ b/cluster/images/splice-debug/Dockerfile
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:latest
+# We don't currently have a need for multi-architecture support in this image,
+# so we're hard-coding amd64, and accepting that this will break on arm64.
+FROM --platform=linux/amd64 ubuntu:latest
 RUN apt-get update && apt-get install -y postgresql-client curl
 RUN curl -sSLO https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_amd64.deb && dpkg -i grpcurl_1.9.1_linux_amd64.deb && rm grpcurl_1.9.1_linux_amd64.deb

--- a/cluster/images/splitwell-app/Dockerfile
+++ b/cluster/images/splitwell-app/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 EXPOSE 5213
 EXPOSE 10013

--- a/cluster/images/splitwell-web-ui/Dockerfile
+++ b/cluster/images/splitwell-web-ui/Dockerfile
@@ -2,16 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-FROM nginx:stable
-RUN apt-get update && \
-  apt-get install -y tini
+ARG base_version
+FROM --platform=$BUILDPLATFORM splice-app:${base_version} AS build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-COPY --from=0 app/splice-node/web-uis/splitwell /usr/share/nginx/html/
+COPY --from=xx / /
 
-COPY config.js /tmpl/config.js.tmpl
+RUN xx-apt-get update && \
+  xx-apt-get install -y tini
 
 COPY docker-entrypoint.sh /custom-docker-entrypoint.sh
 RUN chmod 500 /custom-docker-entrypoint.sh
+
+FROM nginx:stable
+
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=build app/splice-node/web-uis/splitwell /usr/share/nginx/html/
+
+COPY config.js /tmpl/config.js.tmpl
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/custom-docker-entrypoint.sh"]

--- a/cluster/images/sv-app/Dockerfile
+++ b/cluster/images/sv-app/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 EXPOSE 10013
 

--- a/cluster/images/sv-web-ui/Dockerfile
+++ b/cluster/images/sv-web-ui/Dockerfile
@@ -2,16 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-FROM nginx:stable
-RUN apt-get update && \
-    apt-get install -y gettext tini
-COPY default.conf /etc/nginx/conf.d
-COPY --from=0 app/splice-node/web-uis/sv /usr/share/nginx/html/
+ARG base_version
+FROM --platform=$BUILDPLATFORM splice-app:${base_version} AS build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-COPY config.js /tmpl/config.js.tmpl
+COPY --from=xx / /
+
+RUN xx-apt-get update && \
+  xx-apt-get install -y tini
 
 COPY docker-entrypoint.sh /custom-docker-entrypoint.sh
 RUN chmod 500 /custom-docker-entrypoint.sh
+
+FROM nginx:stable
+
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=build app/splice-node/web-uis/sv /usr/share/nginx/html/
+
+COPY default.conf /etc/nginx/conf.d
+COPY config.js /tmpl/config.js.tmpl
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/custom-docker-entrypoint.sh"]

--- a/cluster/images/validator-app/Dockerfile
+++ b/cluster/images/validator-app/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG base_version
 
-FROM --platform=linux/amd64 splice-app:${base_version}
+FROM splice-app:${base_version}
 
 EXPOSE 5003
 EXPOSE 10013

--- a/cluster/images/validator-app/pre-bootstrap.sh
+++ b/cluster/images/validator-app/pre-bootstrap.sh
@@ -19,7 +19,8 @@ else
 
     until [ $n -gt $MAX_RETRY ]; do
 
-        if SECRET=$(curl -sSfL -X POST "${ONBOARD_SECRET_URL}" 2> /dev/null); then
+        # splice-app image does not currently have curl installed, so we use wget instead. See comment in splice-app/Dockerfile.
+        if SECRET=$(wget --post-data="" -q -O - "${ONBOARD_SECRET_URL}"); then
             export CN_APP_VALIDATOR_ONBOARDING_SECRET="$SECRET"
             break
         else

--- a/cluster/images/wallet-web-ui/Dockerfile
+++ b/cluster/images/wallet-web-ui/Dockerfile
@@ -2,16 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG base_version
-FROM --platform=linux/amd64 splice-app:${base_version}
+# xx provides tools to support easy cross-compilation from Dockerfiles, see https://github.com/tonistiigi/xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-FROM nginx:stable
-RUN apt-get update && \
-    apt-get install -y gettext tini
-COPY default.conf /etc/nginx/conf.d
-COPY --from=0 app/splice-node/web-uis/wallet /usr/share/nginx/html/
+ARG base_version
+FROM --platform=$BUILDPLATFORM splice-app:${base_version} AS build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
-COPY config.js /tmpl/config.js.tmpl
+COPY --from=xx / /
+
+RUN xx-apt-get update && \
+  xx-apt-get install -y tini
 
 COPY docker-entrypoint.sh /custom-docker-entrypoint.sh
 RUN chmod 500 /custom-docker-entrypoint.sh
+
+FROM nginx:stable
+
+COPY --from=build /usr/bin/tini /usr/bin/tini
+COPY --from=build /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=build app/splice-node/web-uis/wallet /usr/share/nginx/html/
+
+COPY default.conf /etc/nginx/conf.d
+COPY config.js /tmpl/config.js.tmpl
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/custom-docker-entrypoint.sh"]

--- a/project/BuildUtil.scala
+++ b/project/BuildUtil.scala
@@ -14,11 +14,16 @@ object BuildUtil {
     private val stdoutBuffer = mutable.Buffer[String]()
 
     override def out(s: => String): Unit = {
-      buffer.append(s)
-      stdoutBuffer.append(s)
+      synchronized {
+        buffer.append(s)
+        stdoutBuffer.append(s)
+      }
     }
 
-    override def err(s: => String): Unit = buffer.append(s)
+    override def err(s: => String): Unit =
+      synchronized {
+        buffer.append(s)
+      }
 
     override def buffer[T](f: => T): T = f
 
@@ -26,12 +31,16 @@ object BuildUtil {
       * stdout and stderr are interleaved.
       */
     def output(linePrefix: String = ""): String =
-      buffer.map(l => s"$linePrefix$l").mkString(System.lineSeparator)
+      synchronized {
+        buffer.map(l => s"$linePrefix$l").mkString(System.lineSeparator)
+      }
 
     /** Like output but excludes stderr.
       */
     def outputStdout(linePrefix: String = ""): String =
-      stdoutBuffer.map(l => s"$linePrefix$l").mkString(System.lineSeparator)
+      synchronized {
+        stdoutBuffer.map(l => s"$linePrefix$l").mkString(System.lineSeparator)
+      }
   }
 
   /** Utility function to run a (shell) command. */


### PR DESCRIPTION
This PR updates branch isegall/multi-arch-fix-digests of Splice from the latest changes as of version 0.2.1-snapshot.20240912.6969.0.v02a45cb7, commit DACH-NY/canton-network-node@02a45cb7f