### PR TITLE
examples, sv-helm: Remove ledgerApiAudience from validator-values.yaml

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/validator-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/validator-values.yaml
@@ -21,9 +21,6 @@ auth:
   # replace OIDC_AUTHORITY_VALIDATOR_AUDIENCE with the audience of your choice
   audience: "OIDC_AUTHORITY_VALIDATOR_AUDIENCE"
 
-  # replace OIDC_AUTHORITY_LEDGER_API_AUDIENCE with the audience of your choice
-  ledgerApiAudience: "OIDC_AUTHORITY_LEDGER_API_AUDIENCE"
-
   # replace OIDC_AUTHORITY_URL with your provider's OIDC URL
   jwksUrl: "https://OIDC_AUTHORITY_URL/.well-known/jwks.json"
 


### PR DESCRIPTION
ledgerApiAudience hasn't been used for very long time now. Removing it to avoid confusion. Audience for ledger API is supposed to be set in the related secret now.