### PR TITLE
Update Splice release-line-0.3.1 to version 0.3.1 (automatic PR)

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-snapshot.20241125.14510.0.ve28b8f3c",
+  "version": "3.2.0-snapshot.20241128.14513.0.v4a3d4dd7",
   "tooling_sdk_version": "3.1.0-snapshot.20240717.13187.0.va47ab77f",
-  "sha256": "sha256:145hgnkv7hpbc6f5p732wgcjiwbq9m33fl39610mi32a60smwccq"
+  "sha256": "sha256:07sbn2irdd6q8qfwhd96whxsj1llwjxga2irzkdvmvr07ai2wb34"
 }


### PR DESCRIPTION
This PR updates branch release-line-0.3.1 of Splice from the latest changes as of version 0.3.1, commit DACH-NY/canton-network-node@65d49e36a2