### PR TITLE
Update Splice main to version 0.3.19-snapshot.20250331.8667.0.vc13f0b62 (automatic PR)

### DIFF
--- a/cluster/images/splice-test-ci/Dockerfile
+++ b/cluster/images/splice-test-ci/Dockerfile
@@ -29,6 +29,7 @@ RUN whoami && \
 	git config --global --add safe.directory '*'
 
 ENV COURSIER_CACHE=/cache/coursier
+ENV CI=true
 
 COPY target/LICENSE .
 COPY target/gha-runner-rpc.py .


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.3.19-snapshot.20250331.8667.0.vc13f0b62, commit DACH-NY/canton-network-node@c13f0b6229