### PR TITLE
Update Splice main to version 0.3.19-snapshot.20250401.8684.0.v73401e00 (automatic PR)

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -100,7 +100,7 @@ abstract class ValidatorPreflightIntegrationTestBase
   }
 
   protected def limitValidatorUsers() = {
-    val users = validatorClient.listUsers()
+    val users = eventuallySucceeds()(validatorClient.listUsers())
 
     val targetNumber = 40 // TODO(tech-debt): consider de-hardcoding this
     val offboardThreshold = 50 // TODO(tech-debt): consider de-hardcoding this
@@ -114,7 +114,7 @@ abstract class ValidatorPreflightIntegrationTestBase
         .foreach { user =>
           {
             logger.debug(s"Offboarding user: ${user}")
-            validatorClient.offboardUser(user)
+            eventuallySucceeds()(validatorClient.offboardUser(user))
           }
         }
     } else {

--- a/cluster/images/local.mk
+++ b/cluster/images/local.mk
@@ -52,7 +52,7 @@ else
     # Local builds (which may be on an M1) are explicitly constrained
     # to x86.
     platform_opt := --platform=linux/amd64
-    repo = NoRepoForLocalBuild
+    repo = "https://github.com/digital-asset/decentralized-canton-sync-dev"
     commit_sha = NoShaForLocalBuild
 endif
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -115,15 +115,16 @@ if not version:
     sys.exit(1)
 chart_version = version
 
-# TODO(#17226): Make the helm_repo_prefix also correct for snapshots (not an OCI one). For this case we'll also need to:
-# - put somewhere the "helm repo add" and "helm repo update" commands.
-# - put somewhere the docker login command to jfrog for docker-compose.
 if re.match(r"^[0-9]+.[0-9]+.[0-9]+$", version):
     # For releases, we download artifacts from GitHub Releases
     download_url = f"https://github.com/digital-asset/decentralized-canton-sync/releases/download/v{version}"
+    helm_repo_prefix = os.getenv("OCI_RELEASE_HELM_REGISTRY")
+    docker_repo_prefix = os.getenv("RELEASE_DOCKER_REGISTRY")
 else:
     # For snapshots, we download artifacts through the gcs proxy on the cluster
     download_url = "/cn-release-bundles"
+    helm_repo_prefix = os.getenv("OCI_DEV_HELM_REGISTRY")
+    docker_repo_prefix = os.getenv("DEV_DOCKER_REGISTRY")
 
 # Sphinx does not allow something like ``|version|``
 # so instead we define a replacement that includes the formatting.
@@ -153,5 +154,6 @@ rst_prolog = f"""
 .. |bundle_download_link| replace:: :raw-html:`<a class="reference external" href="{download_url}/{version}_splice-node.tar.gz">Download Bundle</a>`
 .. |openapi_download_link| replace:: :raw-html:`<a class="reference external" href="{download_url}/{version}_openapi.tar.gz">Download OpenAPI specs</a>`
 
-.. |helm_repo_prefix| replace:: oci://ghcr.io/digital-asset/decentralized-canton-sync/helm
+.. |helm_repo_prefix| replace:: {helm_repo_prefix}
+.. |docker_repo_prefix| replace:: {docker_repo_prefix}
 """

--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-snapshot.20250317.14561.0.vebee7f95",
+  "version": "3.2.0-snapshot.20250326.14563.0.v15d43574",
   "tooling_sdk_version": "3.1.0-snapshot.20240717.13187.0.va47ab77f",
-  "sha256": "sha256:035ric1wb7b8f2njd76qkrq186jdgc9c5v26l8chy2car37wnf3y"
+  "sha256": "sha256:1v7drib5jham6qjq9aklb79m6yqqkm0mib69ywjkqciwm5hv4jbh"
 }


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.3.19-snapshot.20250401.8684.0.v73401e00, commit DACH-NY/canton-network-node@73401e00a1